### PR TITLE
don't try hdr with firefox.

### DIFF
--- a/index.html
+++ b/index.html
@@ -45,7 +45,9 @@ let probeHdr = () => {
     let tmpCanvas = document.createElement('canvas');
     tmpCanvas.width = 1;
     tmpCanvas.height = 1;
-    tmpCanvas.getContext('2d', {colorSpace: 'rec2100-pq', pixelFormat: 'float16'});
+    let ctx = tmpCanvas.getContext('2d', {colorSpace: 'rec2100-pq', pixelFormat: 'float16'});
+    // make it fail on firefox...
+    ctx.getContextAttributes();
     addMessage('HDR canvas supported', 'green');
     return true;
   } catch (ex) {


### PR DESCRIPTION
We make an call to getContextAttributes(), which will lead to an error that we then catch when using firefox (until HDR functions in firefox are implemented). Only using getContext with colorSpace argument will not make it fail, which is why in the current version, firefox always seems to provide an HDR canvas. This is not the case, so we make it fail.